### PR TITLE
Add simple web app to log results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # juegos-interescuelas
-Aplicación para registrar y mostrar resultados de los Juegos Interescuelas (Fuerzas Militares y Policía)
+
+Aplicación web para registrar y mostrar resultados de los Juegos Interescuelas.
+
+## Estructura
+- `index.html` Página principal con el formulario y la tabla de resultados.
+- `script.js` Contiene la lógica para enviar los datos y actualizar la tabla.
+- `style.css` Estilos básicos y diseño responsivo para dispositivos móviles.
+
+## Uso
+Abra `index.html` en su navegador. Complete el formulario y presione **Guardar** para registrar el resultado. Modifique la variable `endpoint` en `script.js` con la URL de su Google Apps Script para almacenar los datos en una hoja de cálculo.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Juegos Interescuelas</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Registro de Juegos Interescuelas</h1>
+
+    <form id="result-form">
+        <div class="form-row">
+            <label for="fecha">Fecha:</label>
+            <input type="date" id="fecha" name="fecha" required>
+        </div>
+        <div class="form-row">
+            <label for="escuela">Escuela:</label>
+            <input type="text" id="escuela" name="escuela" required>
+        </div>
+        <div class="form-row">
+            <label for="fuerza">Fuerza:</label>
+            <input type="text" id="fuerza" name="fuerza" required>
+        </div>
+        <div class="form-row">
+            <label for="deporte">Deporte:</label>
+            <select id="deporte" name="deporte" required>
+                <option value="">Seleccione...</option>
+                <option value="futbol">Fútbol</option>
+                <option value="ajedrez">Ajedrez</option>
+                <option value="atletismo">Atletismo</option>
+            </select>
+        </div>
+        <div class="form-row">
+            <label for="tipo">Tipo de Encuentro:</label>
+            <input type="text" id="tipo" name="tipo" required>
+        </div>
+        <div class="form-row">
+            <label for="partA">Participante A:</label>
+            <input type="text" id="partA" name="partA" required>
+        </div>
+        <div class="form-row">
+            <label for="partB">Participante B:</label>
+            <input type="text" id="partB" name="partB" required>
+        </div>
+        <div class="form-row" id="resultadoA-container">
+            <label for="resA">Resultado A:</label>
+            <input type="text" id="resA" name="resA" required>
+        </div>
+        <div class="form-row" id="resultadoB-container">
+            <label for="resB">Resultado B:</label>
+            <input type="text" id="resB" name="resB" required>
+        </div>
+        <div class="form-row">
+            <label for="observaciones">Observaciones:</label>
+            <textarea id="observaciones" name="observaciones"></textarea>
+        </div>
+        <button type="submit">Guardar</button>
+    </form>
+
+    <table id="results-table">
+        <thead>
+            <tr>
+                <th>Fecha</th>
+                <th>Escuela</th>
+                <th>Fuerza</th>
+                <th>Deporte</th>
+                <th>Tipo</th>
+                <th>Participante A</th>
+                <th>Participante B</th>
+                <th>Resultado A</th>
+                <th>Resultado B</th>
+                <th>Observaciones</th>
+            </tr>
+        </thead>
+        <tbody>
+        </tbody>
+    </table>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,93 @@
+const form = document.getElementById('result-form');
+const tableBody = document.querySelector('#results-table tbody');
+const deporteSelect = document.getElementById('deporte');
+const resALabel = document.querySelector('#resultadoA-container label');
+const resAInput = document.getElementById('resA');
+const resBLabel = document.querySelector('#resultadoB-container label');
+const resBInput = document.getElementById('resB');
+
+const endpoint = 'YOUR_APPS_SCRIPT_URL'; // Reemplazar con URL real
+
+function updateResultLabels() {
+    const deporte = deporteSelect.value;
+    switch (deporte) {
+        case 'futbol':
+            resALabel.textContent = 'Goles A:';
+            resBLabel.textContent = 'Goles B:';
+            resAInput.type = 'number';
+            resBInput.type = 'number';
+            break;
+        case 'ajedrez':
+            resALabel.textContent = 'Resultado:';
+            resBLabel.textContent = '—';
+            resAInput.type = 'text';
+            resBInput.type = 'hidden';
+            break;
+        case 'atletismo':
+            resALabel.textContent = 'Marca A:';
+            resBLabel.textContent = 'Marca B:';
+            resAInput.type = 'text';
+            resBInput.type = 'text';
+            break;
+        default:
+            resALabel.textContent = 'Resultado A:';
+            resBLabel.textContent = 'Resultado B:';
+            resAInput.type = 'text';
+            resBInput.type = 'text';
+    }
+}
+
+deporteSelect.addEventListener('change', updateResultLabels);
+
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = {
+        fecha: form.fecha.value,
+        escuela: form.escuela.value,
+        fuerza: form.fuerza.value,
+        deporte: form.deporte.value,
+        tipo: form.tipo.value,
+        participanteA: form.partA.value,
+        participanteB: form.partB.value,
+        resultadoA: form.resA.value,
+        resultadoB: form.resB.value,
+        observaciones: form.observaciones.value,
+    };
+
+    try {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            mode: 'no-cors',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        console.log('Enviado', response);
+        addRow(data);
+        form.reset();
+        updateResultLabels();
+    } catch (err) {
+        console.error('Error al enviar', err);
+    }
+});
+
+function addRow(data) {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+        <td>${data.fecha}</td>
+        <td>${data.escuela}</td>
+        <td>${data.fuerza}</td>
+        <td>${data.deporte}</td>
+        <td>${data.tipo}</td>
+        <td>${data.participanteA}</td>
+        <td>${data.participanteB}</td>
+        <td>${data.resultadoA}</td>
+        <td>${data.resultadoB}</td>
+        <td>${data.observaciones}</td>
+    `;
+    tableBody.appendChild(row);
+}
+
+// Inicializar etiquetas correctamente
+updateResultLabels();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,77 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 1rem;
+}
+
+h1 {
+    text-align: center;
+}
+
+form {
+    max-width: 600px;
+    margin: 0 auto 2rem;
+    padding: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f9f9f9;
+}
+
+.form-row {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.5rem;
+}
+
+.form-row label {
+    margin-bottom: 0.25rem;
+}
+
+.form-row input,
+.form-row select,
+.form-row textarea {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    padding: 0.5rem 1rem;
+    background: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #0056b3;
+}
+
+#results-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#results-table th,
+#results-table td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+@media (min-width: 600px) {
+    .form-row {
+        flex-direction: row;
+        align-items: center;
+    }
+    .form-row label {
+        width: 150px;
+        margin-bottom: 0;
+    }
+    .form-row input,
+    .form-row select,
+    .form-row textarea {
+        flex: 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add responsive web interface to register game results
- support sport-dependent result fields with JavaScript
- include basic styling
- document how to use the app

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0c77a90832b81abd807dc626105